### PR TITLE
use https repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "repositories": [
         {
             "type": "pear",
-            "url": "http://pear.horde.org"
+            "url": "https://pear.horde.org"
         }
     ],
     "require": {


### PR DESCRIPTION
Without this:

```
$ composer install
Loading composer repositories with package information
Initializing PEAR repository http://pear.horde.org
PEAR repository from http://pear.horde.org could not be loaded. Your configuration does not allow connections to http://pear.horde.org/channel.xml. See https://getcomposer.org/doc/06-config.md#secure-http for details.
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.
...
```

Make composer happy

```
$ composer install
Loading composer repositories with package information
Initializing PEAR repository https://pear.horde.org
Updating dependencies (including require-dev)
Package operations: 5 installs, 0 updates, 0 removals
  - Installing pear-pear.horde.org/horde_util (2.5.8): Loading from cache
  - Installing pear-pear.horde.org/horde_stream_wrapper (2.1.3): Loading from cache
  - Installing pear-pear.horde.org/horde_translation (2.2.2): Loading from cache
  - Installing pear-pear.horde.org/horde_exception (2.0.8): Loading from cache
  - Installing pear-pear.horde.org/horde_support (2.2.0): Loading from cache
Writing lock file
Generating autoload files

$ phpunit -c test/Horde/SessionHandler/phpunit.xml test/Horde/SessionHandler
PHPUnit 5.7.22 by Sebastian Bergmann and contributors.

..................SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS...... 65 / 71 ( 91%)
......                                                            71 / 71 (100%)

Time: 71 ms, Memory: 8.00MB

OK, but incomplete, skipped, or risky tests!
Tests: 71, Assertions: 88, Skipped: 41.
```