### PR TITLE
Remove ini_set('session.save_handler').

### DIFF
--- a/lib/Horde/SessionHandler.php
+++ b/lib/Horde/SessionHandler.php
@@ -92,7 +92,6 @@ class Horde_SessionHandler
         $this->_storage = $storage;
 
         if (empty($this->_params['noset'])) {
-            ini_set('session.save_handler', 'user');
             session_set_save_handler(
                 array($this, 'open'),
                 array($this, 'close'),


### PR DESCRIPTION
This chokes on PHP7.2 and appears to be unnecessary.

See also: https://github.com/symphonycms/symphony-2/issues/2783

