### PR TITLE
refactor(SessionHandler): migrate to modern HashTable and add cross-session admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,9 @@ run-tests.log
 /phpstan.neon
 # PHPStan cache directory
 /.phpstan.cache/
+
+# Added by horde-components QC --fix-qc-issues
+# Horde installer plugin runtime data
+/var/
+# Horde installer plugin web-accessible directory
+/web/

--- a/lib/Horde/SessionHandler/Storage/Hashtable.php
+++ b/lib/Horde/SessionHandler/Storage/Hashtable.php
@@ -21,6 +21,10 @@
  * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package   SessionHandler
  * @since     2.2.0
+ *
+ * @deprecated Use {@see \Horde\SessionHandler\Storage\ModernHashtableBackend},
+ *             which depends on the PSR-4 Horde\HashTable\LockableHashTable
+ *             interface and supports phpredis as well as Predis.
  */
 class Horde_SessionHandler_Storage_Hashtable extends Horde_SessionHandler_Storage
 {

--- a/src/SessionAdministrator.php
+++ b/src/SessionAdministrator.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\SessionHandler;
+
+use Generator;
+use Horde\SessionHandler\Exception\CapabilityException;
+use Horde\SessionHandler\Exception\SessionException;
+
+/**
+ * Cross-session inspection and administration service.
+ *
+ * Operates on stored sessions other than the one currently active in this
+ * PHP process. Callers include admin tools (list active sessions, force
+ * logout one), security flows (password change → invalidate all OTHER
+ * sessions for the user), and ops jobs (background cleanup).
+ *
+ * This is deliberately separate from {@see SessionHandler}, which manages
+ * the lifecycle of the SINGLE active session in the current request.
+ *
+ * Capability requirements
+ * -----------------------
+ * The injected backend must implement {@see SessionStorageBackend} (mandatory)
+ * for delete/load. Methods that enumerate sessions additionally require
+ * {@see IterableSessionBackend}; calling them against a non-iterable backend
+ * throws {@see CapabilityException}.
+ *
+ * Methods that filter by user (findByUser, destroyAllForUser) inspect the
+ * payload of each enumerated session. The user identifier is read via the
+ * "horde/auth/userId" path used by HordeSession, matching the wire layout
+ * of {@see \Horde\Core\Session\HordeSession::getAuthenticatedUser()}. Other
+ * Session implementations can extract via the same path or override by
+ * subclassing.
+ *
+ * Performance note
+ * ----------------
+ * findByUser/destroyAllForUser iterate all sessions and load each one.
+ * Acceptable for admin tools; not for hot paths. A backend-specific
+ * user-indexed implementation can replace this service in deployments
+ * where session counts are large.
+ */
+class SessionAdministrator
+{
+    public function __construct(
+        protected readonly SessionStorageBackend $backend,
+        protected readonly SessionFactory $factory,
+        protected readonly SessionSerializer $serializer,
+    ) {}
+
+    /**
+     * Enumerate all known session IDs in the backend.
+     *
+     * @return Generator<SessionId>
+     *
+     * @throws CapabilityException If the backend cannot enumerate sessions.
+     * @throws SessionException    On backend failure during enumeration.
+     */
+    public function listAll(): Generator
+    {
+        if (!$this->backend instanceof IterableSessionBackend) {
+            throw new CapabilityException(
+                'Backend ' . $this->backend::class . ' does not support session enumeration; '
+                . 'implement IterableSessionBackend to enable listing.'
+            );
+        }
+
+        foreach ($this->backend->listSessions() as $id) {
+            yield $id;
+        }
+    }
+
+    /**
+     * Load a stored session by ID.
+     *
+     * Returns null if the session does not exist, has expired, or its
+     * payload is corrupt and cannot be deserialized.
+     */
+    public function load(SessionId $id): ?Session
+    {
+        $payload = $this->backend->load($id);
+        if ($payload === null) {
+            return null;
+        }
+
+        try {
+            $data = $this->serializer->deserialize($payload);
+        } catch (SessionException) {
+            return null;
+        }
+
+        return $this->factory->restore($id, $data);
+    }
+
+    /**
+     * Forcibly delete a session.
+     *
+     * Idempotent: removing a non-existent session is not an error.
+     */
+    public function destroy(SessionId $id): void
+    {
+        $this->backend->delete($id);
+    }
+
+    /**
+     * Locate every session whose authenticated user matches $userId.
+     *
+     * Iterates the backend and inspects each payload. Sessions that fail
+     * to deserialize are silently skipped — they're invalid and should be
+     * cleaned up by GC, not reported here.
+     *
+     * @return list<SessionId>
+     *
+     * @throws CapabilityException If the backend cannot enumerate sessions.
+     */
+    public function findByUser(string $userId): array
+    {
+        $matches = [];
+
+        foreach ($this->listAll() as $sessionId) {
+            $session = $this->load($sessionId);
+            if ($session === null) {
+                continue;
+            }
+
+            if ($this->extractUserId($session) === $userId) {
+                $matches[] = $sessionId;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * Forcibly destroy all of $userId's sessions, optionally keeping one.
+     *
+     * Used by "sign out everywhere" flows and by password-change handlers
+     * that want to invalidate other live sessions while leaving the
+     * current one intact.
+     *
+     * @param SessionId|null $exceptId  Session to keep (typically the
+     *                                  caller's current session ID).
+     *
+     * @throws CapabilityException If the backend cannot enumerate sessions.
+     */
+    public function destroyAllForUser(string $userId, ?SessionId $exceptId = null): void
+    {
+        foreach ($this->findByUser($userId) as $id) {
+            if ($exceptId !== null && $id->equals($exceptId)) {
+                continue;
+            }
+            $this->destroy($id);
+        }
+    }
+
+    /**
+     * Extract the authenticated user ID from a session payload.
+     *
+     * Default implementation reads "horde/auth/userId" — the wire layout
+     * used by HordeSession. Override in a subclass for non-Horde session
+     * shapes.
+     */
+    protected function extractUserId(Session $session): ?string
+    {
+        $payload = $session->toPayload();
+        $value = $payload['horde']['auth/userId'] ?? null;
+
+        return is_string($value) ? $value : null;
+    }
+}

--- a/src/Storage/HashtableBackend.php
+++ b/src/Storage/HashtableBackend.php
@@ -33,6 +33,11 @@ use Horde\SessionHandler\SessionStorageBackend;
  * Sessions are stored as opaque blobs with a TTL derived from the
  * expiration timestamp. An optional tracking set allows enumeration
  * of active sessions.
+ *
+ * @deprecated Use {@see ModernHashtableBackend}, which depends on the PSR-4
+ *             Horde\HashTable\LockableHashTable interface instead of the
+ *             legacy Horde_HashTable_Base & Horde_HashTable_Lock intersection.
+ *             The modern backend supports phpredis as well as Predis.
  */
 final class HashtableBackend implements
     SessionStorageBackend,

--- a/src/Storage/ModernHashtableBackend.php
+++ b/src/Storage/ModernHashtableBackend.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2013-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author Michael Slusarz <slusarz@horde.org>
+ */
+
+namespace Horde\SessionHandler\Storage;
+
+use DateTimeImmutable;
+use Generator;
+use Horde\HashTable\HashTableException;
+use Horde\HashTable\LockableHashTable;
+use Horde\SessionHandler\AdministrativeSessionBackend;
+use Horde\SessionHandler\Exception\CapabilityException;
+use Horde\SessionHandler\Exception\SessionException;
+use Horde\SessionHandler\IterableSessionBackend;
+use Horde\SessionHandler\SerializedSessionPayload;
+use Horde\SessionHandler\SessionId;
+use Horde\SessionHandler\SessionStorageBackend;
+
+/**
+ * HashTable-based session storage backend (Memcache/Redis).
+ *
+ * Uses the PSR-4 Horde\HashTable\LockableHashTable interface. Sessions are
+ * stored as opaque blobs with a TTL derived from the expiration timestamp.
+ * An optional tracking set allows enumeration of active sessions.
+ *
+ * This is the modern counterpart to {@see HashtableBackend}, which accepts
+ * the legacy Horde_HashTable_Base & Horde_HashTable_Lock intersection. New
+ * deployments select this backend via the SessionHandlerFactory; the legacy
+ * backend remains for the deprecation period.
+ */
+final class ModernHashtableBackend implements
+    SessionStorageBackend,
+    IterableSessionBackend,
+    AdministrativeSessionBackend
+{
+    /**
+     * @param LockableHashTable $hashTable  HashTable instance with cross-process locking
+     * @param bool              $track      Whether to track active session IDs
+     * @param string            $trackKey   Key used to store the tracking set
+     */
+    public function __construct(
+        private readonly LockableHashTable $hashTable,
+        private readonly bool $track = false,
+        private readonly string $trackKey = 'horde_sessions_track_ht',
+    ) {}
+
+    public function load(SessionId $id): ?SerializedSessionPayload
+    {
+        $result = $this->hashTable->get($id->id);
+
+        if ($result === null) {
+            return null;
+        }
+
+        return new SerializedSessionPayload($result);
+    }
+
+    public function save(SessionId $id, SerializedSessionPayload $payload, DateTimeImmutable $expiresAt): void
+    {
+        $ttl = max(0, $expiresAt->getTimestamp() - time());
+
+        try {
+            $this->hashTable->set($id->id, $payload->getData(), $ttl > 0 ? $ttl : null);
+
+            if ($this->track) {
+                $this->hashTable->lock($this->trackKey);
+
+                try {
+                    $ids = $this->getTrackIds();
+                    $ids[$id->id] = 1;
+                    $this->hashTable->set($this->trackKey, json_encode($ids));
+                } finally {
+                    $this->hashTable->unlock($this->trackKey);
+                }
+            }
+        } catch (HashTableException $e) {
+            throw new SessionException($e->getMessage(), (int) $e->getCode(), $e);
+        }
+    }
+
+    public function delete(SessionId $id): void
+    {
+        try {
+            $this->hashTable->delete($id->id);
+
+            if ($this->track) {
+                $this->hashTable->lock($this->trackKey);
+
+                try {
+                    $ids = $this->getTrackIds();
+                    unset($ids[$id->id]);
+                    $this->hashTable->set($this->trackKey, json_encode($ids));
+                } finally {
+                    $this->hashTable->unlock($this->trackKey);
+                }
+            }
+        } catch (HashTableException $e) {
+            throw new SessionException($e->getMessage(), (int) $e->getCode(), $e);
+        }
+    }
+
+    /** @return Generator<SessionId> */
+    public function listSessions(): Generator
+    {
+        if (!$this->track) {
+            throw new CapabilityException('Session tracking is not enabled; cannot list sessions');
+        }
+
+        try {
+            $this->trackGC();
+
+            $ids = $this->getTrackIds();
+
+            foreach (array_keys($ids) as $id) {
+                yield new SessionId($id);
+            }
+        } catch (HashTableException $e) {
+            throw new SessionException($e->getMessage(), (int) $e->getCode(), $e);
+        }
+    }
+
+    public function expire(SessionId $id): void
+    {
+        $this->delete($id);
+    }
+
+    /**
+     * Garbage-collect the tracking set by removing IDs whose
+     * sessions have already expired from the HashTable.
+     */
+    public function trackGC(): void
+    {
+        try {
+            $this->hashTable->lock($this->trackKey);
+
+            try {
+                $ids = $this->getTrackIds();
+                $altered = false;
+
+                foreach (array_keys($ids) as $key) {
+                    if (!$this->hashTable->exists($key)) {
+                        unset($ids[$key]);
+                        $altered = true;
+                    }
+                }
+
+                if ($altered) {
+                    $this->hashTable->set($this->trackKey, json_encode($ids));
+                }
+            } finally {
+                $this->hashTable->unlock($this->trackKey);
+            }
+        } catch (HashTableException) {
+            // Best effort -- silently ignore tracking GC failures
+        }
+    }
+
+    /**
+     * Retrieve the current set of tracked session IDs.
+     *
+     * @return array<string, int>
+     */
+    private function getTrackIds(): array
+    {
+        $raw = $this->hashTable->get($this->trackKey);
+
+        if ($raw === null) {
+            return [];
+        }
+
+        if (!is_string($raw)) {
+            return [];
+        }
+
+        $ids = json_decode($raw, true);
+
+        if (!is_array($ids)) {
+            return [];
+        }
+
+        return $ids;
+    }
+}

--- a/test/unit/Storage/HashtableBackendTest.php
+++ b/test/unit/Storage/HashtableBackendTest.php
@@ -26,6 +26,7 @@ use Horde\SessionHandler\Storage\HashtableBackend;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use TypeError;
 
 /**
  * Concrete test double that extends Horde_HashTable_Base and implements
@@ -147,7 +148,7 @@ class HashtableBackendTest extends TestCase
     {
         $hashTable = new NonLockingHashTableStub();
 
-        $this->expectException(\TypeError::class);
+        $this->expectException(TypeError::class);
 
         new HashtableBackend($hashTable);
     }


### PR DESCRIPTION
Three additions plus deprecation cleanup:

- **`Horde\SessionHandler\Storage\ModernHashtableBackend`** — new session storage backend that consumes the PSR-4 `Horde\HashTable\LockableHashTable` interface (so phpredis works alongside Predis).
- **`Horde\SessionHandler\SessionAdministrator`** — cross-session inspection/admin service: list, load, destroy, find by user, destroy-all-for-user. Used by `base/admin/sessions.php` and force-logout flows. Operates on the storage backend, not the active session.
- Legacy `Horde_SessionHandler_Storage_Hashtable` and the PSR-4 `HashtableBackend` (legacy-typed) marked `@deprecated`, pointing at `ModernHashtableBackend`.

Refs https://github.com/horde/Core/issues/131