### PR TITLE
fix(builtin): persist sess files with custom save handler

### DIFF
--- a/src/Storage/BuiltinBackend.php
+++ b/src/Storage/BuiltinBackend.php
@@ -49,9 +49,23 @@ final class BuiltinBackend implements SessionStorageBackend
     }
 
     /**
-     * No-op: PHP's built-in session handler writes the data natively.
+     * Persist session data to PHP's default sess_ file layout.
+     *
+     * When Horde registers {@see \Horde\SessionHandler\SessionHandler} as
+     * PHP's save handler, this backend must write the blob itself — PHP no
+     * longer invokes the native handler directly.
      */
-    public function save(SessionId $id, SerializedSessionPayload $payload, DateTimeImmutable $expiresAt): void {}
+    public function save(SessionId $id, SerializedSessionPayload $payload, DateTimeImmutable $expiresAt): void
+    {
+        $file = $this->filePath($id);
+        $written = @file_put_contents($file, $payload->getData(), LOCK_EX);
+
+        if ($written === false) {
+            throw new \RuntimeException(
+                sprintf('Failed to write session file "%s"', $file)
+            );
+        }
+    }
 
     public function delete(SessionId $id): void
     {


### PR DESCRIPTION
# Fix BuiltinBackend session persistence with modern save handler

## Summary

- Implement `BuiltinBackend::save()` to write PHP's default `sess_<id>` session files

## Problem

Horde registers `Horde\SessionHandler\SessionHandler` via `session_set_save_handler()`.
With `sessionhandler.type = builtin`, PHP calls `SessionHandler::write()`, which delegates
to `BuiltinBackend::save()`.

`BuiltinBackend::save()` was a no-op, with a comment assuming PHP's native handler would
still write files. That is no longer true once a custom save handler is installed.

**Symptom:** Login via `login.php` appeared to succeed (no error message), but the next
request loaded an empty session and redirected back to the login form.

Within a single request, auth lived only in memory; nothing was persisted to disk.

## Solution

Write the serialized session blob to `sess_<id>` under the configured save path (same
layout `load()` already reads). Throw `RuntimeException` if the write fails, matching
`FileBackend` behaviour.

## Test plan

- [ ] Configure `sessionhandler.type = Builtin` in a Horde deployment
- [ ] Log in via classic `login.php` with valid credentials
- [ ] Confirm the portal (or initial page) loads on the following request without returning to login
- [ ] Confirm a `sess_<session_id>` file exists under PHP's session save path after login

## Related

- Horde Core session shim mirrors `HordeSession` data into `$_SESSION` before PHP's save
  handler runs; this fix ensures that mirrored payload is actually written when the
  builtin backend is selected.
